### PR TITLE
Fix typo in deps coords

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ There is a rumor that the middleware design may change in the future.
 
 [clj](https://clojure.org/guides/getting_started) dependency information:
 ```clojure
-io.github.clojure/clr.tools.reader {:git/tag "v0.1.0-alpha2" :git/sha "a58009f"}
+io.github.clojure/clr.tools.nrepl {:git/tag "v0.1.0-alpha2" :git/sha "a58009f"}
 ```
 
 ```


### PR DESCRIPTION
Hi @dmiller thanks for all your great work on Clojure. I've been playing around with the new **cljr** tool and found two typos here. One is fixed by this PR but the other is the tag [v0.1.2-alpha2](https://github.com/clojure/clr.tools.nrepl/releases/tag/v0.1.2-alpha2) which I think should be v0.1.0-alpha2