### PR TITLE
Fix dependency information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ There is a rumor that the middleware design may change in the future.
 
 [clj](https://clojure.org/guides/getting_started) dependency information:
 ```clojure
-io.github.clojure/clr.tools.reader {:git/tag "v0.1.0-alpha2" :git/sha "a58009f"}
+io.github.clojure/clr.tools.nrepl {:git/tag "v0.1.2-alpha2" :git/sha "a58009f"}
 ```
 
 ```


### PR DESCRIPTION
I reviewed the [clojars](https://clojars.org/org.clojure.clr/tools.nrepl) one and that is ok, only note is that it is inconsistent on the PATCH part of the version (0.1.0-alpha2 vs 0.1.2-alpha2). 

The Install-Package one I guess it's for PowerShell, but I coundn't found it in [powershell gallery
](https://www.powershellgallery.com/packages?q=clojure) so I suppose that its published somewhere else.  